### PR TITLE
Modify device_erase_size to fix CH559 code flash area

### DIFF
--- a/chflasher.py
+++ b/chflasher.py
@@ -409,7 +409,7 @@ class CHflasher:
                 # self.device_erase_size = 11
             elif self.chipid == 0x59:
                 self.device_flash_size = 64
-                self.device_erase_size = 0x1d
+                self.device_erase_size = 60
         else:
             self.__errorexit('Unknown chip')
         read_cfg_reply = self.__sendcmd(self.chip_v2["read_config"], 30)


### PR DESCRIPTION
For CH559, device_erase_size was specified as 0x1d. But this is
too small to write a larger file. CH559 has 64KB flash ROM and
the first 60KB is used for application code. Following 1KB is
used for application data or code. And the last 3KB is for
boot loader and configuration. As the block size is 1KB, this
device_erase_size should be set to 60.